### PR TITLE
Fixing GenImagePerlinNoise() being stretched, if Image is not rectangular

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -1112,6 +1112,7 @@ Image GenImagePerlinNoise(int width, int height, int offsetX, int offsetY, float
 {
     Color *pixels = (Color *)RL_MALLOC(width*height*sizeof(Color));
 
+    float aspectRatio = (float)width / (float)height;
     for (int y = 0; y < height; y++)
     {
         for (int x = 0; x < width; x++)
@@ -1119,6 +1120,10 @@ Image GenImagePerlinNoise(int width, int height, int offsetX, int offsetY, float
             float nx = (float)(x + offsetX)*(scale/(float)width);
             float ny = (float)(y + offsetY)*(scale/(float)height);
 
+            // Apply aspect ratio compensation to wider side
+            if (width > height) nx *= aspectRatio;
+            else ny /= aspectRatio;
+            
             // Basic perlin noise implementation (not used)
             //float p = (stb_perlin_noise3(nx, ny, 0.0f, 0, 0, 0);
 


### PR DESCRIPTION
I have noticed that when the width and height of GenImagePerlinNoise() are not the same, then the noise will get stretched. So I have added a compensation for it.
Now even if the sides aren´t the same length, the noise won´t get distorted, but rather extended.

Here an image to demonstrate:
On the left is my fix being applied. The noise looks normal.
On the right the current function is being used. The noise is stretched.
![fixedPerlinNoise](https://github.com/user-attachments/assets/04ae3b2b-1c78-42f2-bdfe-c25731748408)